### PR TITLE
Address review findings (daggre)

### DIFF
--- a/examples/spaday/app.html
+++ b/examples/spaday/app.html
@@ -25,7 +25,8 @@
       const client = new Client();
       const { paint } = attach(document.getElementById("graph"), { client });
 
-      const ws = new WebSocket(`ws://${location.host}/ws`);
+      const proto = location.protocol === "https:" ? "wss:" : "ws:";
+      const ws = new WebSocket(`${proto}//${location.host}/ws`);
       ws.binaryType = "arraybuffer";
       ws.addEventListener("message", (e) => {
         client.recv(typeof e.data === "string" ? e.data : new Uint8Array(e.data));

--- a/examples/spaday/app.py
+++ b/examples/spaday/app.py
@@ -1,8 +1,8 @@
 """daggre inside a spaday app: a spaday component tree (heading + graph) authored in Python, with the
 daggre Graph synced over transports.
 
-The shell is authored with spaday (`element` + the `DagreGraph` component); the browser mounts it with
-the spaday runtime and daggre binds the mounted <dagre-graph> to a transports `Client`. Run (needs
+The shell is authored with spaday (`element("dagre-graph")`); the browser mounts it with the spaday
+runtime and daggre binds the mounted <dagre-graph> to a transports `Client`. Run (needs
 spaday + daggre + transports on the path; spaday built)::
 
     PYTHONPATH=../../python:<spaday repo> python examples/spaday/app.py   # -> http://127.0.0.1:8003
@@ -16,7 +16,6 @@ from pathlib import Path
 import transports
 import uvicorn
 from spaday import element
-from spaday.components import DagreGraph
 from starlette.applications import Starlette
 from starlette.responses import FileResponse, JSONResponse
 from starlette.routing import Mount, Route, WebSocketRoute
@@ -40,7 +39,8 @@ def shell() -> dict:
         element("div", style="font-family:system-ui;max-width:960px;margin:24px auto")
         .child(element("h1", style="font-size:18px").text("daggre inside a spaday app"))
         .child(element("p", style="color:#666;font-size:13px").text("Shell authored in spaday; the graph syncs over transports."))
-        .child(DagreGraph().prop("id", "graph").prop("style", "display:block;height:480px;border:1px solid #e6e6e6;border-radius:10px"))
+        # daggre owns the <dagre-graph> element (its bundle defines it); spaday mounts it by tag
+        .child(element("dagre-graph").prop("id", "graph").prop("style", "display:block;height:480px;border:1px solid #e6e6e6;border-radius:10px"))
         .to_node()
     )
 

--- a/js/src/dagre-graph.js
+++ b/js/src/dagre-graph.js
@@ -21,6 +21,9 @@ export class DagreGraph extends HTMLElement {
     Object.assign(this.renderer.shapes(), customShapes);
     Object.assign(this.renderer.arrows(), customArrows);
     this._direction = "top-to-bottom";
+    this._directed = true;
+    this._multigraph = false;
+    this._compound = false;
     this._nodes = [];
     this._edges = [];
   }
@@ -78,8 +81,39 @@ export class DagreGraph extends HTMLElement {
     this.draw();
   }
 
+  get directed() {
+    return this._directed;
+  }
+
+  set directed(value) {
+    this._directed = value !== false;
+    this.draw();
+  }
+
+  get multigraph() {
+    return this._multigraph;
+  }
+
+  set multigraph(value) {
+    this._multigraph = Boolean(value);
+    this.draw();
+  }
+
+  get compound() {
+    return this._compound;
+  }
+
+  set compound(value) {
+    this._compound = Boolean(value);
+    this.draw();
+  }
+
   build() {
-    const g = new graphlib.Graph({ directed: true });
+    const g = new graphlib.Graph({
+      directed: this._directed,
+      multigraph: this._multigraph,
+      compound: this._compound,
+    });
     g.setGraph({
       rankdir: RANKDIR[this._direction] || "TB",
       nodesep: 50,

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -31,6 +31,9 @@ export function attach(el, { client, modelId } = {}) {
     const props = toGraphProps(model);
     /* eslint-disable no-param-reassign */
     el.direction = props.direction;
+    el.directed = props.directed;
+    el.multigraph = props.multigraph;
+    el.compound = props.compound;
     el.nodes = props.nodes;
     el.edges = props.edges;
     /* eslint-enable no-param-reassign */

--- a/js/src/map.js
+++ b/js/src/map.js
@@ -16,6 +16,9 @@ export function toGraphProps(model) {
   }));
   return {
     direction: (model && model.direction) || "top-to-bottom",
+    directed: model ? model.directed !== false : true,
+    multigraph: Boolean(model && model.multigraph),
+    compound: Boolean(model && model.compound),
     nodes,
     edges,
   };

--- a/js/tests/map.test.js
+++ b/js/tests/map.test.js
@@ -21,7 +21,21 @@ describe("toGraphProps", () => {
     expect(props.edges).toEqual([{ from: "a", to: "b", line: "dash", arrowhead: "vee" }]);
   });
 
-  test("defaults direction and tolerates an empty model", () => {
-    expect(toGraphProps({})).toEqual({ direction: "top-to-bottom", nodes: [], edges: [] });
+  test("defaults direction/flags and tolerates an empty model", () => {
+    expect(toGraphProps({})).toEqual({
+      direction: "top-to-bottom",
+      directed: true,
+      multigraph: false,
+      compound: false,
+      nodes: [],
+      edges: [],
+    });
+  });
+
+  test("passes through non-default graph flags", () => {
+    const props = toGraphProps({ directed: false, multigraph: true, compound: true });
+    expect(props.directed).toBe(false);
+    expect(props.multigraph).toBe(true);
+    expect(props.compound).toBe(true);
   });
 });

--- a/python/daggre/web.py
+++ b/python/daggre/web.py
@@ -36,7 +36,7 @@ _PAGE = """<!doctype html>
     <script type="module">
       import {{ connect }} from "/static/index.js";
       connect(document.getElementById("graph"), {{
-        wsUrl: `ws://${{location.host}}/ws`,
+        wsUrl: `${{location.protocol === "https:" ? "wss:" : "ws:"}}//${{location.host}}/ws`,
         wasmUrl: "/static/transports_bg.wasm",
       }});
     </script>

--- a/python/daggre/widget.py
+++ b/python/daggre/widget.py
@@ -52,6 +52,14 @@ class Widget(anywidget.AnyWidget):
             for m in msgs:
                 conn.send({"wire": m})
 
+    def close(self, *args: Any, **kwargs: Any) -> None:
+        """Cancel the background pump and drop the transports connection, then close the widget."""
+        if self._pump_task is not None:
+            self._pump_task.cancel()
+            self._pump_task = None
+        self._server.close(self)
+        super().close(*args, **kwargs)
+
     def _start_pump(self) -> None:
         if self._pump_task is not None:
             return


### PR DESCRIPTION
Follow-up to the port (#57, merged), actioning the daggre ultrareview:

- **HIGH:** the spaday-app example imported `DagreGraph` from spaday, which spaday removed when daggre took ownership of the element — it now builds the node with `element('dagre-graph')`.
- **Med:** `directed`/`multigraph`/`compound` were dropped by the JS mapping (renderer always built `directed: true`); passed through `toGraphProps` → `graphlib.Graph`, with mapper tests.
- **Med:** `Widget._pump` was never cancelled — now cancelled (and the transports connection dropped) on `close()`, fixing a notebook task/object leak.
- **Low:** browser hosts hard-coded `ws://` → derive `ws`/`wss` from `location.protocol`.

Verified: jest 3, eslint/ruff/isort clean, mypy 15 files, pytest 12; spaday-app example imports against the sibling spaday checkout.