### PR TITLE
Adapt to transports 0.4 connection API

### DIFF
--- a/examples/spaday/app.py
+++ b/examples/spaday/app.py
@@ -60,7 +60,7 @@ async def grow(g: daggre.Graph) -> None:
 
 @asynccontextmanager
 async def lifespan(app):
-    tasks = [asyncio.create_task(transports.autoflush(server)), asyncio.create_task(grow(graph))]
+    tasks = [asyncio.create_task(transports.autosync(server)), asyncio.create_task(grow(graph))]
     try:
         yield
     finally:
@@ -72,7 +72,7 @@ app = Starlette(
     routes=[
         Route("/", lambda r: FileResponse(HERE / "app.html")),
         Route("/shell.json", lambda r: JSONResponse(shell())),
-        WebSocketRoute("/ws", transports.starlette_endpoint(server)),
+        WebSocketRoute("/ws", transports.ws_endpoint(server)),
         Mount("/static", StaticFiles(directory=STATIC)),
         Mount("/spaday", StaticFiles(directory=SPADAY_DIST)),
     ],

--- a/python/daggre/tests/test_hosts.py
+++ b/python/daggre/tests/test_hosts.py
@@ -21,7 +21,7 @@ def test_serve_builds_an_app_and_serves_the_page():
 
     app = daggre.serve(g, title="demo graph", background=bg)
     assert isinstance(app, Starlette)
-    with TestClient(app) as client:  # runs the lifespan (autoflush + background)
+    with TestClient(app) as client:  # runs the lifespan (autosync + background)
         resp = client.get("/")
         assert resp.status_code == 200
         assert "demo graph" in resp.text

--- a/python/daggre/web.py
+++ b/python/daggre/web.py
@@ -61,7 +61,7 @@ def serve(
 
     @asynccontextmanager
     async def lifespan(app: Starlette):
-        tasks = [asyncio.create_task(transports.autoflush(server))]
+        tasks = [asyncio.create_task(transports.autosync(server))]
         if background is not None:
             tasks.append(asyncio.create_task(background(graph)))
         try:
@@ -76,7 +76,7 @@ def serve(
     return Starlette(
         routes=[
             Route("/", index),
-            WebSocketRoute("/ws", transports.starlette_endpoint(server)),
+            WebSocketRoute("/ws", transports.ws_endpoint(server)),
             Mount("/static", StaticFiles(directory=STATIC)),
         ],
         lifespan=lifespan,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "pydantic",
     "starlette",
-    "transports>=0.3.0",
+    "transports>=0.4.0",
     "uvicorn",
 ]
 


### PR DESCRIPTION
transports 0.4 renamed the Python connection adapters. Adapt the web host and the spaday example, and require the new release:

- `transports.autoflush` → `transports.autosync`
- `transports.starlette_endpoint` → `transports.ws_endpoint`
- pin `transports>=0.4.0`

The anywidget `Widget` host drives the `Broadcaster` contract directly (`open`/`recv`/`flush`/`close`) and needs no change; the JS frontend is unchanged. Merge once transports 0.4.0 is published.