### PR TITLE
Fix lint errors

### DIFF
--- a/daggre/__init__.py
+++ b/daggre/__init__.py
@@ -2,7 +2,7 @@ __version__ = "0.1.1"
 
 from .core import Arrowhead, Direction, Edge, Graph, LabelPosition, Line, Node, Shape
 
-__all__ = ["Arrowhead", "Direction", "Edge", "Graph", "LabelPosition", "Line", "Node", "Shape", "serve", "Widget"]
+__all__ = ["Arrowhead", "Direction", "Edge", "Graph", "LabelPosition", "Line", "Node", "Shape", "Widget", "serve"]
 
 
 def __getattr__(name: str):

--- a/daggre/core/base.py
+++ b/daggre/core/base.py
@@ -4,8 +4,9 @@ These are plain pydantic v2 models — a `transports.Session` hosts the `Graph` 
 to it (and its nested nodes/edges) directly, so the domain carries no sync machinery of its own.
 """
 
-from pydantic import BaseModel as PydanticBaseModel, Field, model_validator
 from uuid import uuid4
+
+from pydantic import BaseModel as PydanticBaseModel, Field, model_validator
 
 
 class BaseModel(PydanticBaseModel):

--- a/daggre/core/edge.py
+++ b/daggre/core/edge.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from .base import BaseModel
 from .common import Arrowhead, LabelPosition, Line
 from .node import Node
@@ -11,7 +9,7 @@ class Edge(BaseModel):
     tooltip: str = ""
     line: Line = "solid"
     labelposition: LabelPosition = "r"
-    labeloffset: Optional[float] = None
+    labeloffset: float | None = None
     arrowhead: Arrowhead = "vee"
 
     def __lt__(self, other: "Edge") -> bool:

--- a/daggre/core/graph.py
+++ b/daggre/core/graph.py
@@ -1,5 +1,6 @@
+from typing import Any
+
 from pydantic import Field
-from typing import Any, Dict, List, Optional, Union
 
 from .base import BaseModel
 from .common import Direction
@@ -13,10 +14,10 @@ class Graph(BaseModel):
     multigraph: bool = False
     compound: bool = False
     direction: Direction = "top-to-bottom"
-    edges: List[Edge] = Field(default_factory=list)
-    nodes: Dict[str, Node] = Field(default_factory=dict)
+    edges: list[Edge] = Field(default_factory=list)
+    nodes: dict[str, Node] = Field(default_factory=dict)
 
-    def addNode(self, node: Union[str, Node], **node_kwargs: Any) -> Node:
+    def addNode(self, node: str | Node, **node_kwargs: Any) -> Node:
         if isinstance(node, str):
             # a bare reference (e.g. from addEdge) to an existing node: don't clobber its styling
             if node in self.nodes and not node_kwargs:
@@ -31,8 +32,8 @@ class Graph(BaseModel):
 
     def addEdge(
         self,
-        edge_or_node_from_: Union[str, Edge, Node],
-        to_: Optional[Union[str, Node]] = None,
+        edge_or_node_from_: str | Edge | Node,
+        to_: str | Node | None = None,
         **edge_kwargs: Any,
     ) -> None:
         # already an Edge: ensure both endpoints are in the graph, then record it

--- a/daggre/tests/test_all.py
+++ b/daggre/tests/test_all.py
@@ -1,4 +1,4 @@
-from daggre import *  # noqa
+from daggre import *
 
 
 def test_all():

--- a/daggre/tests/test_core.py
+++ b/daggre/tests/test_core.py
@@ -15,7 +15,7 @@ class TestBasic:
         g.addEdge(a_to_b_edge)
         g.addEdge(a_node, b_node)
 
-        assert sorted(list(g.nodes.values())) == [a_node, b_node]
+        assert sorted(g.nodes.values()) == [a_node, b_node]
         assert len(g.edges) == 2
         assert a_to_b_edge in g.edges
 
@@ -35,7 +35,7 @@ class TestBasic:
         g = new_graph
         g.addEdge(a_to_b_edge)
 
-        assert sorted(list(g.nodes.values())) == [a_node, b_node]
+        assert sorted(g.nodes.values()) == [a_node, b_node]
         assert len(g.edges) == 1
         assert a_to_b_edge in g.edges
 

--- a/daggre/tests/test_hosts.py
+++ b/daggre/tests/test_hosts.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 

--- a/daggre/web.py
+++ b/daggre/web.py
@@ -7,14 +7,16 @@ daggre frontend bundle (spaday's `<dagre-graph>`).
 """
 
 import asyncio
-import transports
+from collections.abc import Callable, Coroutine
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
+
+import transports
 from starlette.applications import Starlette
 from starlette.responses import HTMLResponse
 from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.staticfiles import StaticFiles
-from typing import Any, Callable, Coroutine, Optional
 
 STATIC = Path(__file__).parent / "static"
 
@@ -48,7 +50,7 @@ def serve(
     graph: Any,
     *,
     title: str = "daggre",
-    background: Optional[Callable[[Any], Coroutine[Any, Any, None]]] = None,
+    background: Callable[[Any], Coroutine[Any, Any, None]] | None = None,
 ) -> Starlette:
     """Build a Starlette app that serves `graph` live over transports.
 

--- a/daggre/widget.py
+++ b/daggre/widget.py
@@ -7,12 +7,13 @@ loop; outside a loop, call `widget.flush()`. anywidget makes this an ordinary ip
 it composes with any ipywidgets layout.
 """
 
-import anywidget
 import asyncio
+from pathlib import Path
+from typing import Any
+
+import anywidget
 import traitlets
 import transports
-from pathlib import Path
-from typing import Any, Optional
 
 STATIC = Path(__file__).parent / "static"
 _WASM = (STATIC / "transports_bg.wasm").read_bytes()
@@ -30,7 +31,7 @@ class Widget(anywidget.AnyWidget):
         self._session.host(graph)
         self._server = transports.Server(self._session)
         self._opened = False
-        self._pump_task: Optional[asyncio.Task] = None
+        self._pump_task: asyncio.Task | None = None
         self.on_msg(self._on_msg)
 
     def _on_msg(self, _widget: Any, content: Any, _buffers: Any) -> None:

--- a/js/tests/map.test.js
+++ b/js/tests/map.test.js
@@ -9,16 +9,35 @@ describe("toGraphProps", () => {
         b: { name: "b", backgroundColor: "lightblue" },
       },
       edges: [
-        { from_: { name: "a" }, to_: { name: "b" }, line: "dash", arrowhead: "vee" },
+        {
+          from_: { name: "a" },
+          to_: { name: "b" },
+          line: "dash",
+          arrowhead: "vee",
+        },
       ],
     };
     const props = toGraphProps(model);
     expect(props.direction).toBe("left-to-right");
     expect(props.nodes).toEqual([
-      { id: "a", label: "A", shape: "house", color: "red", backgroundColor: undefined },
-      { id: "b", label: "b", shape: undefined, color: undefined, backgroundColor: "lightblue" },
+      {
+        id: "a",
+        label: "A",
+        shape: "house",
+        color: "red",
+        backgroundColor: undefined,
+      },
+      {
+        id: "b",
+        label: "b",
+        shape: undefined,
+        color: undefined,
+        backgroundColor: "lightblue",
+      },
     ]);
-    expect(props.edges).toEqual([{ from: "a", to: "b", line: "dash", arrowhead: "vee" }]);
+    expect(props.edges).toEqual([
+      { from: "a", to: "b", line: "dash", arrowhead: "vee" },
+    ]);
   });
 
   test("defaults direction/flags and tolerates an empty model", () => {
@@ -33,7 +52,11 @@ describe("toGraphProps", () => {
   });
 
   test("passes through non-default graph flags", () => {
-    const props = toGraphProps({ directed: false, multigraph: true, compound: true });
+    const props = toGraphProps({
+      directed: false,
+      multigraph: true,
+      compound: true,
+    });
     expect(props.directed).toBe(false);
     expect(props.multigraph).toBe(true);
     expect(props.compound).toBe(true);


### PR DESCRIPTION
Updates code for the latest Ruff diagnostics without changing lint configuration.\n\n`make lint` passes.